### PR TITLE
Add make request, validate request functions and tests

### DIFF
--- a/Sources/HTTPEngine/HTTPEngine.swift
+++ b/Sources/HTTPEngine/HTTPEngine.swift
@@ -1,6 +1,9 @@
 import Foundation
+import Combine
 
 public typealias Header = [String: String]
+public typealias ValidResponse = Bool
+public typealias ResponseValidationClosure = (Int) -> ValidResponse
 
 public struct HTTPEngine {
     public init() {}
@@ -28,6 +31,43 @@ public struct HTTPEngine {
         }
 
         return request
+    }
+    
+    public func makeRequest(
+        method: HTTPMethod,
+        url urlString: String,
+        body: Data? = nil,
+        header: Header? = nil,
+        validator: ResponseValidationClosure? = nil
+    ) -> AnyPublisher<Data, Error> {
+
+        guard let url = URL(string: urlString) else {
+            return ThrowingPublisher(forType: Data.self, throws: Errors.Request.invalidURL)
+        }
+
+        return buildRequest(method: method, url: url, body: body, header: header)
+            .dataTaskPublisher()
+            .eraseToAnyPublisher()
+            .tryMap { value -> Data in
+                try self.validateResponse(value.response, validator: validator)
+                return value.data
+            }
+        .eraseToAnyPublisher()
+    }
+    
+    func validateResponse(_ response: URLResponse?, validator: ResponseValidationClosure? = nil) throws {
+        let response = try response as? HTTPURLResponse ??? Errors.Response.couldNotRetrieveStatusCode
+
+        guard let validator = validator else {
+            if let error = Errors.Response.errorWith(statusCode: response.statusCode) {
+                throw error
+            }
+            return
+        }
+
+        guard validator(response.statusCode) else {
+            throw Errors.Response.unexpectedStatusCode(response)
+        }
     }
     
 }

--- a/Sources/HTTPEngine/Utilities.swift
+++ b/Sources/HTTPEngine/Utilities.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Combine
+
+public extension URLRequest {
+    func dataTaskPublisher() -> URLSession.DataTaskPublisher {
+        return URLSession.shared.dataTaskPublisher(for: self)
+    }
+}
+
+public func ThrowingPublisher<T>(forType type: T.Type, throws error: Error) -> AnyPublisher<T, Error> {
+    Result<T?, Error> { nil }
+        .publisher
+        .eraseToAnyPublisher()
+        .tryMap {
+            guard let value = $0 else {
+                throw error
+            }
+            return value
+        }.eraseToAnyPublisher()
+}
+
+infix operator ??? : TernaryPrecedence
+public func ???<T>(_ left: Optional<T>, right: Error) throws -> T {
+    guard let value = left else { throw right }
+    return value
+}

--- a/Tests/HTTPEngineTests/TestUtilities.swift
+++ b/Tests/HTTPEngineTests/TestUtilities.swift
@@ -1,0 +1,65 @@
+import XCTest
+import Combine
+
+private var cancelables: [AnyCancellable] = []
+
+extension AnyPublisher {
+    func noFailureOnMain() -> AnyPublisher<Output, Never> {
+        assertNoFailure()
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+
+    @discardableResult
+    func assertResult(
+        _ function: String = #function,
+        test: XCTestCase,
+        _ assertions: @escaping (Output) -> Void = { _ in }
+    ) -> AnyPublisher<Output, Failure> {
+
+        let expectation = test.expectation(description: function)
+
+        self
+            .noFailureOnMain()
+            .sink { value in
+                assertions(value)
+                expectation.fulfill()
+        }
+        .store(in: &cancelables)
+
+        test.wait(for: [expectation], timeout: 1)
+        return self
+    }
+
+    @discardableResult
+    func assertNoError(
+        _ function: String = #function,
+        test: XCTestCase
+    ) -> AnyPublisher<Output, Failure> {
+        assertResult(function, test: test) { _ in }
+    }
+
+    @discardableResult
+    func assertError(
+        _ function: String = #function,
+        test: XCTestCase,
+        _ assertions: @escaping (Failure) -> Void
+    ) -> AnyPublisher<Output, Failure> {
+
+        let expectation = test.expectation(description: function)
+
+        self
+            .receive(on: DispatchQueue.main)
+            .tryCatch { error -> Empty<Output, Error> in
+                assertions(error)
+                expectation.fulfill()
+                return Empty(completeImmediately: true)
+        }
+        .assertNoFailure()
+        .sink { _ in XCTFail(function) }
+        .store(in: &cancelables)
+
+        test.wait(for: [expectation], timeout: 1)
+        return self
+    }
+}

--- a/Tests/HTTPEngineTests/UtilityTests.swift
+++ b/Tests/HTTPEngineTests/UtilityTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+import Foundation
+@testable import HTTPEngine
+
+class UtitlityTests: XCTestCase {
+    func testTripQuestionsThrowsIfNil() {
+        let x: Int? = nil
+        do {
+            _ = try x ??? Errors.Request.invalidURL
+            XCTFail(#function)
+        }
+        catch let error{
+            XCTAssertEqual(error.localizedDescription, Errors.Request.invalidURL.localizedDescription)
+        }
+    }
+    
+    func testTripQuestionsUnwraps() {
+        let x: Int? = 1
+        do {
+            XCTAssertEqual(try x ??? Errors.Request.invalidURL, 1)
+        }
+        catch {
+            XCTFail(#function)
+        }
+    }
+    
+    func testThrowingPublisherThrows() {
+        ThrowingPublisher(forType: Int.self, throws: Errors.Request.invalidURL)
+            .assertError(test: self) {
+                XCTAssertEqual($0.localizedDescription, Errors.Request.invalidURL.localizedDescription)
+        }
+    }
+    
+    
+    static var allTests = [
+        ("??? operator throws when unwrapping a nil", testTripQuestionsThrowsIfNil),
+        ("??? unwraps values", testTripQuestionsUnwraps),
+        ("Test throwing publisher throws", testThrowingPublisherThrows)
+        
+    ]
+
+}


### PR DESCRIPTION
## Summary

Adds function to make a request with status code validation.

By default the request will fail if the status code is not between 200 - 299

A request can be made with a validator to override that range:
` { statusCode == 202 }`

